### PR TITLE
Support running a bone script from command-line

### DIFF
--- a/bone.c
+++ b/bone.c
@@ -2213,7 +2213,10 @@ void bone_init(int argc, char **argv) {
 }
 
 my char *mod2file(const char *mod) {
-  char *res = malloc(strlen(mod) + 4);
+  size_t len = strlen(mod);
+  if (len > 3 && strcmp(".bn", mod + (len - 3)) == 0)
+    return strdup(mod);
+  char *res = malloc(len + 4);
   strcat(strcpy(res, mod), ".bn");
   return res;
 }
@@ -2231,6 +2234,8 @@ void bone_load(const char *mod) {
   bool fail = false;
   any e;
   try {
+    if (look() == '#')
+      skip_until('\n');
     while ((e = bone_read()) != ENDOFFILE)
       eval_toplevel_expr(e);
   } catch {

--- a/main.c
+++ b/main.c
@@ -22,6 +22,10 @@ int main(int argc, char **argv) {
   bone_init(argc, argv);
   bone_posix_init();
   bone_load("prelude");
+  if (argc > 1) {
+    bone_load(argv[1]);
+    return 0;
+  }
   printf("Bone Lisp " BONE_VERSION);
   bone_repl();
   return 0;


### PR DESCRIPTION
If command-line arguments are passed to bone, the first argument is
taken to be a name of the module (`.bn` suffix is added if not given).
Then that module is loaded and the REPL is not started.

Also, when loading a module, if the first line of the file starts with
'#', that line is skipped, to allow for executable bone scripts with a
shebang line.

Example:

```
$ cat test-say.bn 
#!./bone
(say "ARGS= ")
(print *program-args*)
(say "\n")

$ chmod +x test-say.bn 

$ ./test-say.bn abc def ghi
ARGS= ("./bone" "./test-say.bn" "abc" "def" "ghi")
```
