### PR TITLE
Error on division by zero

### DIFF
--- a/bone.c
+++ b/bone.c
@@ -2002,9 +2002,15 @@ DEFSUB(fullmult) {
     ires *= any2int(n);
   last_value = int2any(ires);
 }
-DEFSUB(fastdiv) { last_value = int2any(any2int(args[0]) / any2int(args[1])); }
+DEFSUB(fastdiv) {
+  if (any2int(args[1]) == 0)
+    generic_error("division by zero", args[1]);
+  last_value = int2any(any2int(args[0]) / any2int(args[1]));
+}
 DEFSUB(fulldiv) {
   CSUB_fullmult(&args[1]);
+  if (any2int(last_value) == 0)
+    generic_error("division by zero", last_value);
   last_value = int2any(any2int(args[0]) / any2int(last_value));
 }
 DEFSUB(listp) { last_value = to_bool(is_cons(args[0]) || is_nil(args[0])); }

--- a/tests/base.bn
+++ b/tests/base.bn
@@ -27,3 +27,14 @@
 (test "quasiquote"
   (eq? 3 ``,,(+ 1 2)))
 
+(test "`/` with 2 operands"
+  (eq? 4 (/ 20 5))
+  (eq? 4 (/ 21 5)))
+
+(test "`/` with more than 2 operands"
+  (eq? 5 (/ 30 2 3))
+  (eq? 5 (/ 31 2 3)))
+
+(test-error "`/` by zero"
+  (/ 3 0)
+  (/ 10 2 0 5))


### PR DESCRIPTION
Instead of SIGFPE, throw a normal bone error when dividing by zero. Also added
tests for `/`.
