### PR TITLE
Add sys.gettimeofday? and std/bench

### DIFF
--- a/boneposix.c
+++ b/boneposix.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <time.h>
@@ -145,6 +146,15 @@ DEFSUB(time) {
   time_t t = time(NULL);
   ses();
   bone_result((t != -1) ? int2any(t) : BFALSE);
+}
+
+// FIXME: not Y2038-safe w/ 32bit-fixnums
+DEFSUB(gettimeofday) {
+  struct timeval tv;
+  int res = gettimeofday(&tv, NULL);
+  ses();
+  bone_result((res != -1) ? cons(int2any(tv.tv_sec), single(int2any(tv.tv_usec)))
+                          : BFALSE);
 }
 
 DEFSUB(mkdir) {
@@ -311,6 +321,7 @@ void bone_posix_init() {
   bone_register_csub(CSUB_chdir, "sys.chdir?", 1, 0);
   bone_register_csub(CSUB_getcwd, "sys.getcwd?", 0, 0);
   bone_register_csub(CSUB_time, "sys.time?", 0, 0);
+  bone_register_csub(CSUB_gettimeofday, "sys.gettimeofday?", 0, 0);
   bone_register_csub(CSUB_mkdir, "sys.mkdir?", 2, 0);
   bone_register_csub(CSUB_rmdir, "sys.rmdir?", 1, 0);
   bone_register_csub(CSUB_link, "sys.link?", 2, 0);

--- a/main.c
+++ b/main.c
@@ -22,6 +22,7 @@ int main(int argc, char **argv) {
   bone_init(argc, argv);
   bone_posix_init();
   bone_load("prelude");
+  bone_load("posixprelude");
   if (argc > 1) {
     bone_load(argv[1]);
     return 0;

--- a/posix.bn
+++ b/posix.bn
@@ -59,6 +59,9 @@ return `#f`.")
 (defsub (sys.time?)
   "Return seconds since epoch.")
 
+(defsub (sys.gettimeofday?)
+  "Return a list `(seconds microseconds)` of the time since epoch.")
+
 (defsub (sys.mkdir? dir mode)
   "Create the directory `dir` with permissions as specified by `mode`.")
 

--- a/posixprelude.bn
+++ b/posixprelude.bn
@@ -1,0 +1,29 @@
+;;;; posixprelude.bn -- Wrappers for POSIX functions   -*- bone -*-
+;;;; Copyright (C) 2016 Dov Murik
+;;;;
+;;;; Permission to use, copy, modify, and/or distribute this software for any
+;;;; purpose with or without fee is hereby granted, provided that the above
+;;;; copyright notice and this permission notice appear in all copies.
+;;;;
+;;;; THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+;;;; WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+;;;; MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+;;;; ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+;;;; WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+;;;; ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+;;;; OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+(defsub (gettimeofday)
+  "Return a list `(seconds microseconds)` of the time since epoch."
+  (aif (sys.gettimeofday?)
+       it
+    (err "Error calling POSIX gettimeofday, errno=" sys.errno)))
+
+(defsub (timeofday-diff t2 t1)
+  "Return the number of microseconds between `t1` and `t2`, which are both
+two-element lists of the form `(sec usec)` (as returned from `gettimeofday`)."
+  (let ((t1-sec  (car t1))
+        (t1-usec (cadr t1))
+        (t2-sec  (car t2))
+        (t2-usec (cadr t2)))
+    (+ (* 1000000 (- t2-sec t1-sec)) (- t2-usec t1-usec))))

--- a/std/bench.bn
+++ b/std/bench.bn
@@ -1,0 +1,32 @@
+;;;; std/bench.bn -- Benchmark library.   -*- bone -*-
+;;;; Copyright (C) 2016 Dov Murik
+;;;;
+;;;; Permission to use, copy, modify, and/or distribute this software for any
+;;;; purpose with or without fee is hereby granted, provided that the above
+;;;; copyright notice and this permission notice appear in all copies.
+;;;;
+;;;; THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+;;;; WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+;;;; MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+;;;; ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+;;;; WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+;;;; ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+;;;; OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+(defsub (measure-time f)
+  "Execute `f` (function with no arguments) and return the number of microseconds elapsed."
+  (with start-time (gettimeofday)
+    (f)
+    (timeofday-diff (gettimeofday) start-time)))
+
+(defmac (say-time f)
+  "Execute `f` (any Bone Lisp expression) and print the time it took.  Example:
+
+    (say-time (unfoldr =0? id -- 10000))
+    Running (unfoldr =0? id -- 10000) ... Elapsed: 15117 usecs"
+  `(do
+    (say "Running ")
+    (print ',f)
+    (say " ... ")
+    (with elapsed (measure-time | ,f)
+      (say "Elapsed: " elapsed " usecs\n"))))

--- a/tests/bench.bn
+++ b/tests/bench.bn
@@ -1,0 +1,22 @@
+;;;; tests/posix.bn -- std/bench library tests.   -*- bone -*-
+;;;; Copyright (C) 2016 Dov Murik
+;;;;
+;;;; Permission to use, copy, modify, and/or distribute this software for any
+;;;; purpose with or without fee is hereby granted, provided that the above
+;;;; copyright notice and this permission notice appear in all copies.
+;;;;
+;;;; THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+;;;; WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+;;;; MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+;;;; ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+;;;; WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+;;;; ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+;;;; OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+(use std/tap)
+(use std/bench)
+
+(test-plan "tests/bench.bn")
+
+(test "`measure-time`"
+  (<? 10 (measure-time | (unfoldr (partial =? 1000) id ++ 0)))) ; This lambda should take more than 10 usecs to execute

--- a/tests/posix.bn
+++ b/tests/posix.bn
@@ -1,0 +1,30 @@
+;;;; tests/posix.bn -- POSIX operations tests.   -*- bone -*-
+;;;; Copyright (C) 2016 Dov Murik
+;;;;
+;;;; Permission to use, copy, modify, and/or distribute this software for any
+;;;; purpose with or without fee is hereby granted, provided that the above
+;;;; copyright notice and this permission notice appear in all copies.
+;;;;
+;;;; THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+;;;; WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+;;;; MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+;;;; ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+;;;; WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+;;;; ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+;;;; OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+(use std/tap)
+
+(test-plan "tests/posix.bn")
+
+(test "`gettimeofday`"
+  (let ((t (gettimeofday))
+        (sec (car t))
+        (usec (cadr t)))
+    (and (<=? 0 usec 999999)
+         (<? 946684800 sec))))  ; seconds are after 2000-01-01 00:00:00
+
+(test "`timeofday-diff`"
+  (eq? 1000000 (timeofday-diff '(31 0) '(30 0)))
+  (eq? -1000000 (timeofday-diff '(30 0) '(31 0)))
+  (eq? 300000 (timeofday-diff '(31 100000) '(30 800000))))


### PR DESCRIPTION
### Commit 1

Microsecond-timing available via `sys.gettimeofday?` (added `tests/posix.bn` too):

```
Bone Lisp 0.4.0-pre
@0: (sys.gettimeofday?)
(1467210688 959696)
@1: (sys.gettimeofday?)
(1467210694 231724)
```
### Commit 2

Add `std/bench` module to allow measuring elapsed time of code:

```
Bone Lisp 0.4.0-pre
@0: (use std/bench)
(std/bench)
@1: (mysub (long-op x) (unfoldr =0? id -- x))
#sub(id=0x7f993fee00d5 name=long-op argc=1 take-rest?=#f)
@2: (long-op 10)
(1 2 3 4 5 6 7 8 9 10)
@3: (say-time (long-op 10))
Running (long-op 10) ... Elapsed: 30 usecs
#t
@4: (say-time (long-op 100))
Running (long-op 100) ... Elapsed: 233 usecs
#t
@5: (say-time (long-op 1000))
Running (long-op 1000) ... Elapsed: 2341 usecs
#t
@6: (say-time (long-op 10000))
Running (long-op 10000) ... Elapsed: 8607 usecs
#t
```

As for the second commit, I'm not sure the names I chose (`usec-diff`, `measure`, `say-time`) are the best fit. Suggestions for changes are welcome.
