### PR TITLE
fix integer arithmetic (+,-,*,/) for more than 2 arguments

### DIFF
--- a/bone.c
+++ b/bone.c
@@ -1991,7 +1991,7 @@ my any quasiquote(any x) {
 
 DEFSUB(fastplus) { last_value = int2any(any2int(args[0]) + any2int(args[1])); }
 DEFSUB(fullplus) {
-  int ires = 0;
+  int64_t ires = 0;
   foreach(n, args[0])
     ires += any2int(n);
   last_value = int2any(ires);
@@ -2026,7 +2026,7 @@ DEFSUB(say) {
 }
 DEFSUB(fastminus) { last_value = int2any(any2int(args[0]) - any2int(args[1])); }
 DEFSUB(fullminus) {
-  int res = any2int(args[0]);
+  int64_t res = any2int(args[0]);
   foreach(x, args[1])
     res -= any2int(x);
   last_value = int2any(res);
@@ -2056,7 +2056,7 @@ DEFSUB(each) {
 }
 DEFSUB(fastmult) { last_value = int2any(any2int(args[0]) * any2int(args[1])); }
 DEFSUB(fullmult) {
-  int ires = 1;
+  int64_t ires = 1;
   foreach(n, args[0])
     ires *= any2int(n);
   last_value = int2any(ires);

--- a/tests/base.bn
+++ b/tests/base.bn
@@ -27,13 +27,26 @@
 (test "quasiquote"
   (eq? 3 ``,,(+ 1 2)))
 
+(test "`+` with more than 2 operands"
+  (eq? 10 (+ 1 2 3 4))
+  (eq? 576460752303423487 (+ 576460752303423485 1 1)))
+
+(test "`-` with more than 2 operands"
+  (eq? 4 (- 10 1 2 3))
+  (eq? 576460752303423485 (- 576460752303423487 1 1)))
+
+(test "`*` with more than 2 operands"
+  (eq? 24 (* 1 2 3 4))
+  (eq? 288230376151711744 (* 72057594037927936 2 2)))
+
 (test "`/` with 2 operands"
   (eq? 4 (/ 20 5))
   (eq? 4 (/ 21 5)))
 
 (test "`/` with more than 2 operands"
   (eq? 5 (/ 30 2 3))
-  (eq? 5 (/ 31 2 3)))
+  (eq? 5 (/ 31 2 3))
+  (eq? 72057594037927936 (/ 288230376151711744 2 2)))
 
 (test-error "`/` by zero"
   (/ 3 0)


### PR DESCRIPTION
Operations on values larger than 2^31 failed because intermediate results were stored in an `int` variable instead of a `int64_t` variable.
