### PR TITLE
Adding in travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+os:
+  - linux
+
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+sudo: false
+
+script:
+    - make
+    - make test
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-CC=clang
 FLAGS=-std=gnu99 -Wall -W -Wextra -Wno-unused -Wno-unused-parameter -g
 #FLAGS=-std=gnu99 -Wall -W -Wextra -Wno-unused -Wno-unused-parameter -O3
 EXTRA_MODULES=boneposix.o

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Bone Lisp could maybe become useful for soft real-time systems (e.g. as a script
 
 ## Status
 
+[![Build Status](https://travis-ci.org/wolfgangj/bone-lisp.svg?branch=master)](https://travis-ci.org/wolfgangj/bone-lisp)
+
 ### What it does
 
 * Lexical scoping & closures


### PR DESCRIPTION
As per #13 you will have to authorise travis via:

Please visit https://travis-ci.org/wolfgangj/bone-lisp
sign in with github
authorise it for your account
then on https://travis-ci.org/wolfgangj/bone-lisp
there should be a gray box next to bone-lisp, clicking it will turn it green
once green we are good to go and I can do the rest via PRs :)

To see proof that this config builds, see https://travis-ci.org/mkfifo/bone-lisp/builds/144694857

I am building this for linux under both clang and gcc, it failed under osx (see https://travis-ci.org/mkfifo/bone-lisp/builds/144694305) so I have not included osx in this submitted config.
